### PR TITLE
fixed syntax to resolve metadata error during cookbook upload.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
+name             "autossec"
 maintainer       "Julien Vehent"
-maintainer_email "julien@linuxwall.info
-license          "GPLv2
+maintainer_email "julien@linuxwall.info"
+license          "GPLv2"
 description      "Installs/Configures ossec"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.0"


### PR DESCRIPTION
Missing double quote ["] after 'maintainer' and 'license' fields in metadata.rb.
Added name field with value "autossec".
