### PR TITLE
Adding service_name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Default attributes from the ossec-server role:
           ]
         }
       },
+      :server => {
+        :server_name => 'ossec-hids-server'
+      },
       :syscheck => {
         :frequency => '7200',
         :alert_new_files => 'yes',
@@ -461,6 +464,9 @@ run_list(
 )
 default_attributes(
   :ossec => {
+    :server => {
+      :server_name => 'ossec-hids-client'
+    },
     :syscheck => {
       :frequency => '7200',
       :alert_new_files => 'yes',

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Default attributes from the ossec-server role:
         }
       },
       :server => {
-        :server_name => 'ossec-hids-server'
+        :service_name => 'ossec-hids-server'
       },
       :syscheck => {
         :frequency => '7200',
@@ -465,7 +465,7 @@ run_list(
 default_attributes(
   :ossec => {
     :client => {
-      :server_name => 'ossec-hids-client'
+      :service_name => 'ossec-hids-client'
     },
     :syscheck => {
       :frequency => '7200',

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ run_list(
 )
 default_attributes(
   :ossec => {
-    :server => {
+    :client => {
       :server_name => 'ossec-hids-client'
     },
     :syscheck => {

--- a/attributes/ossec.rb
+++ b/attributes/ossec.rb
@@ -12,6 +12,8 @@ default[:ossec][:agents] = {}
 default[:ossec][:rules] = {}
 default[:ossec][:email_alerts] = {}
 default[:ossec][:agent][:enable] = true
+default[:ossec][:server][:service_name] = "ossec-hids-server"
+default[:ossec][:client][:service_name] = "ossec-hids-client"
 
 
 # internal options, you probably don't want to touch that

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -56,7 +56,7 @@ end
 
 service "ossec-agent" do
   provider Chef::Provider::Service::Init
-  service_name "ossec-hids-client"
+  service_name node[:ossec][:client][:server_name]
   supports :start => true, :stop => true, :restart => true, :status => true
   action [ :start ]
   only_if "test -e /var/ossec/etc/ossec.conf && test -e /var/ossec/etc/client.keys"

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -56,7 +56,7 @@ end
 
 service "ossec-agent" do
   provider Chef::Provider::Service::Init
-  service_name node[:ossec][:client][:server_name]
+  service_name node[:ossec][:client][:service_name]
   supports :start => true, :stop => true, :restart => true, :status => true
   action [ :start ]
   only_if "test -e /var/ossec/etc/ossec.conf && test -e /var/ossec/etc/client.keys"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -13,7 +13,7 @@ package "ossec-hids-server"
 
 service "ossec-server" do
   provider Chef::Provider::Service::Init
-  service_name node[:ossec][:server][:server_name]
+  service_name node[:ossec][:server][:service_name]
   supports :start => true, :stop => true, :restart => true, :status => true
   action [ :start ]
   only_if "test -e /var/ossec/etc/ossec.conf"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -13,7 +13,7 @@ package "ossec-hids-server"
 
 service "ossec-server" do
   provider Chef::Provider::Service::Init
-  service_name "ossec-hids-server"
+  service_name node[:ossec][:server][:server_name]
   supports :start => true, :stop => true, :restart => true, :status => true
   action [ :start ]
   only_if "test -e /var/ossec/etc/ossec.conf"


### PR DESCRIPTION
Allows for customization of the service names depending on how the package defines the service name.
Default values set to "ossec-hids-server" and "ossec-hids-client"
